### PR TITLE
Support `gitea_oauth2_app` `confidential_client` flag

### DIFF
--- a/docs/resources/oauth2_app.md
+++ b/docs/resources/oauth2_app.md
@@ -20,6 +20,10 @@ Handling [gitea oauth application](https://docs.gitea.io/en-us/oauth2-provider/)
 - `name` (String) OAuth Application name
 - `redirect_uris` (Set of String) Accepted redirect URIs
 
+### Optional
+
+- `confidential_client` (Boolean) If set to false, it will be a public client (PKCE will be required)
+
 ### Read-Only
 
 - `client_id` (String) OAuth2 Application client id

--- a/gitea/resource_gitea_oauth_app.go
+++ b/gitea/resource_gitea_oauth_app.go
@@ -96,9 +96,16 @@ func resourceOauth2AppUpcreate(d *schema.ResourceData, meta interface{}) (err er
 		return fmt.Errorf("attribute %s must be set and must be a string", oauth2KeyName)
 	}
 
+	confidentialClient, confidentialClientOk := d.Get(oauth2KeyConfidentialClient).(bool)
+
+	if !confidentialClientOk {
+		return fmt.Errorf("attribute %s must be set and must be a bool", oauth2KeyConfidentialClient)
+	}
+
 	opts := gitea.CreateOauth2Option{
-		Name:         name,
-		RedirectURIs: redirectURIs,
+		Name:               name,
+		ConfidentialClient: confidentialClient,
+		RedirectURIs:       redirectURIs,
 	}
 
 	var oauth2 *gitea.Oauth2
@@ -183,9 +190,10 @@ func setOAuth2ResourceData(app *gitea.Oauth2, d *schema.ResourceData) (err error
 	d.SetId(app.ClientID)
 
 	for k, v := range map[string]interface{}{
-		oauth2KeyName:         app.Name,
-		oauth2KeyRedirectURIs: schema.NewSet(schema.HashString, CollapseStringList(app.RedirectURIs)),
-		oauth2KeyClientId:     app.ClientID,
+		oauth2KeyName:               app.Name,
+		oauth2KeyConfidentialClient: app.ConfidentialClient,
+		oauth2KeyRedirectURIs:       schema.NewSet(schema.HashString, CollapseStringList(app.RedirectURIs)),
+		oauth2KeyClientId:           app.ClientID,
 	} {
 		err = d.Set(k, v)
 		if err != nil {

--- a/gitea/resource_gitea_oauth_app.go
+++ b/gitea/resource_gitea_oauth_app.go
@@ -113,7 +113,7 @@ func resourceOauth2AppUpcreate(d *schema.ResourceData, meta interface{}) (err er
 	if d.IsNewResource() {
 		oauth2, _, err = client.CreateOauth2(opts)
 	} else {
-		oauth2, err := searchOauth2AppByClientId(client, d.Id())
+		oauth2, err = searchOauth2AppByClientId(client, d.Id())
 
 		if err != nil {
 			return err

--- a/gitea/resource_gitea_oauth_app.go
+++ b/gitea/resource_gitea_oauth_app.go
@@ -8,10 +8,11 @@ import (
 )
 
 const (
-	oauth2KeyName         string = "name"
-	oauth2KeyRedirectURIs string = "redirect_uris"
-	oauth2KeyClientId     string = "client_id"
-	oauth2KeyClientSecret string = "client_secret"
+	oauth2KeyName               string = "name"
+	oauth2KeyConfidentialClient string = "confidential_client"
+	oauth2KeyRedirectURIs       string = "redirect_uris"
+	oauth2KeyClientId           string = "client_id"
+	oauth2KeyClientSecret       string = "client_secret"
 )
 
 func resourceGiteaOauthApp() *schema.Resource {
@@ -36,6 +37,12 @@ func resourceGiteaOauthApp() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Description: "Accepted redirect URIs",
+			},
+			oauth2KeyConfidentialClient: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "If set to false, it will be a public client (PKCE will be required)",
 			},
 			oauth2KeyClientId: {
 				Type:        schema.TypeString,

--- a/vendor/code.gitea.io/sdk/gitea/oauth2.go
+++ b/vendor/code.gitea.io/sdk/gitea/oauth2.go
@@ -13,12 +13,13 @@ import (
 
 // Oauth2 represents an Oauth2 Application
 type Oauth2 struct {
-	ID           int64     `json:"id"`
-	Name         string    `json:"name"`
-	ClientID     string    `json:"client_id"`
-	ClientSecret string    `json:"client_secret"`
-	RedirectURIs []string  `json:"redirect_uris"`
-	Created      time.Time `json:"created"`
+	ID                 int64     `json:"id"`
+	Name               string    `json:"name"`
+	ClientID           string    `json:"client_id"`
+	ClientSecret       string    `json:"client_secret"`
+	RedirectURIs       []string  `json:"redirect_uris"`
+	ConfidentialClient bool      `json:"confidential_client"`
+	Created            time.Time `json:"created"`
 }
 
 // ListOauth2Option for listing Oauth2 Applications
@@ -28,8 +29,9 @@ type ListOauth2Option struct {
 
 // CreateOauth2Option required options for creating an Application
 type CreateOauth2Option struct {
-	Name         string   `json:"name"`
-	RedirectURIs []string `json:"redirect_uris"`
+	Name               string   `json:"name"`
+	ConfidentialClient bool     `json:"confidential_client"`
+	RedirectURIs       []string `json:"redirect_uris"`
 }
 
 // CreateOauth2 create an Oauth2 Application and returns a completed Oauth2 object.


### PR DESCRIPTION
Hi there, thank you for this provider!

I found out that there's a missing field in `gitea_oauth2_app`.

https://try.gitea.io/api/swagger#/user/userCreateOAuth2Application 
![image](https://github.com/Lerentis/terraform-provider-gitea/assets/29378614/2e764c60-58d0-4dbe-969b-9acb0c680bef)

Currently it's implicitly passed as `false` therefore creating apps that require PKCE. This PR simply allows the consumer to configure the value.

From the swagger file above it looks like the default should be `true`, not a big deal but I think it's worth mentioning it.
If we set the default to `true` it would be a breaking change since it could break some consumers that might expect it to false since now it's ignored.

Reference: https://docs.gitea.com/next/development/oauth2-provider#confidential-client

